### PR TITLE
Fix cost cap logic

### DIFF
--- a/complete_ai_analyzer.py
+++ b/complete_ai_analyzer.py
@@ -256,7 +256,8 @@ class CloudAnalyzer:
         tokens_in  = int(len(content.split()) * 1.3)
         tokens_out = 600
         cost_est   = self._calculate_cost(tokens_in, tokens_out)
-        if cost_est > 100:  # p99 cost guard
+        # Abort if estimated cost exceeds the $0.01 p99 cap
+        if cost_est > 0.01:
             raise RuntimeError("Query too large – would exceed $0.01 budget")
 
         # Build prompt


### PR DESCRIPTION
## Summary
- enforce documented $0.01 cost cap in `complete_ai_analyzer.py`
- add clarifying comment about the threshold

## Testing
- `python3 -m py_compile complete_ai_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_6840410784808327a436ce59b18aa3e9